### PR TITLE
docs: 展示 Trendshift Python 日榜徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/202902?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-202902" target="_blank" rel="noopener noreferrer">
+    <img src="https://trendshift.io/api/badge/trendshift/repositories/202902/daily?language=Python" alt="EvoMap/AutoResearch | Trendshift" width="250" height="55"/>
+  </a>
+</p>
+
+<p align="center">
   <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/License-Apache--2.0-47C9E7"></a>
   <a href="https://www.python.org/"><img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-0B1324"></a>
   <a href="https://evomap.ai"><img alt="EvoMap ecosystem" src="https://img.shields.io/badge/EvoMap-Ecosystem-47C9E7"></a>

--- a/README_CN.md
+++ b/README_CN.md
@@ -11,6 +11,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/202902?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-202902" target="_blank" rel="noopener noreferrer">
+    <img src="https://trendshift.io/api/badge/trendshift/repositories/202902/daily?language=Python" alt="EvoMap/AutoResearch | Trendshift" width="250" height="55"/>
+  </a>
+</p>
+
+<p align="center">
   <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/License-Apache--2.0-47C9E7"></a>
   <a href="https://www.python.org/"><img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-0B1324"></a>
   <a href="https://evomap.ai"><img alt="EvoMap ecosystem" src="https://img.shields.io/badge/EvoMap-Ecosystem-47C9E7"></a>


### PR DESCRIPTION
## 这个 PR 做什么

在中英文 README 顶部加入 Trendshift 官方 Python 日榜徽章，尺寸为 250 × 55，点击进入 AutoResearch 的 Trendshift 页面。

## 为什么

展示项目在 Trendshift Python 日榜获得第 1 名的记录。徽章链接与排版已经过预览确认。

## 怎么验证的

- 实际渲染确认徽章可加载，显示 Python 与第 1 名，链接指向 AutoResearch。
- 两份 README 与确认的预览逐字节一致。
- Ruff、模型引用、配置投影、敏感信息、发布树与公开知识清单检查通过。
- 本次仅新增徽章 HTML，不修改运行代码。

## 范围自查

- [x] 标题是单一关注点
- [x] 改动可独立回退
- [x] 仅修改 README.md 与 README_CN.md
- [x] 已检查实际渲染
- [x] 共享文档改动进入 main

## 关联

无；仅为已确认排版的文档小改动。已查询在途 PR，无重复工作。
