### PR TITLE
docs: use bundled knowledge directions in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,17 +184,17 @@ List the available directions or filter them by keyword:
 .venv/bin/python src/idea_forge/b_library.py agent
 ```
 
-The four registered directions are used by default. To choose your own combination, add the following to `config/providers.local.json`:
+The registered directions are used by default. To choose your own combination, add the following to `config/providers.local.json`:
 
 ```json
 {
   "idea_forge": {
-    "b_directions": ["Agent_运行时与沙箱", "视觉推理"]
+    "b_directions": ["agent_memory", "llm_reasoning"]
   }
 }
 ```
 
-Each direction name corresponds to a Markdown filename under `knowledge_base/`. Adding directions increases generation and review calls; start with a small set when validating a new setup.
+The example uses knowledge files included in this repository. Each direction name is a Markdown filename under `knowledge_base/` without the `.md` suffix. To use a custom direction, create its knowledge file before adding its name to the configuration. Adding directions increases generation and review calls; start with a small set when validating a new setup.
 
 ### 4.4 Optional: Draft a Knowledge Direction with GPT Researcher
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -190,17 +190,17 @@ set +a
 .venv/bin/python src/idea_forge/b_library.py agent
 ```
 
-默认使用已注册的四个方向。要指定自己的组合，在 `config/providers.local.json` 中加入：
+默认使用已注册的方向。要指定自己的组合，在 `config/providers.local.json` 中加入：
 
 ```json
 {
   "idea_forge": {
-    "b_directions": ["Agent_运行时与沙箱", "视觉推理"]
+    "b_directions": ["agent_memory", "llm_reasoning"]
   }
 }
 ```
 
-方向名对应 `knowledge_base/` 下的 Markdown 文件名。每增加一个方向，构思和评审调用量都会增加；第一次运行建议先选少量方向验证流程。
+示例使用仓库自带的知识文件。方向名对应 `knowledge_base/` 下不带 `.md` 后缀的 Markdown 文件名。使用自定义方向前，先创建对应的知识文件，再把名称加入配置。每增加一个方向，构思和评审调用量都会增加；第一次运行建议先选少量方向验证流程。
 
 ### 4.4 可选：用 GPT Researcher 起草知识方向
 

--- a/tests/test_b_direction_selection.py
+++ b/tests/test_b_direction_selection.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import builtins
 import json
+import re
 import sys
 import types
 
@@ -244,3 +245,17 @@ def test_the_pending_rerun_uses_the_configured_directions(forge, monkeypatch, tm
     assert seen["b_ids"] == ["llm_reasoning"]
     assert json.loads(pending.read_text())["seeds"] == [], "the queue is drained after a run"
     assert published == [True]
+
+
+@pytest.mark.parametrize("document", ["README.md", "README_CN.md"])
+def test_readme_direction_example_uses_bundled_knowledge(forge, document):
+    text = (REPO / document).read_text(encoding="utf-8")
+    examples = [json.loads(block) for block in re.findall(r"```json\n(.*?)```", text, re.S)
+                if '"b_directions"' in block]
+    assert examples, f"{document} must include a direction configuration example"
+    for config in examples:
+        forge.llm.load_config = lambda: config
+        selected, _ = forge.bl.select_b_directions()
+        assert selected
+        for direction in selected:
+            assert forge.bl.knowledge_path(direction["id"]) is not None


### PR DESCRIPTION
## What changes

The English and Chinese README direction examples now use `agent_memory` and `llm_reasoning`, both included in `knowledge_base/`. The instructions also explain that a custom knowledge file must exist before its name is added to the configuration.

## Why

Copying the previous example into `config/providers.local.json` caused `python run_pending_forge.py` to reject both names before model execution. This was an incorrect documentation example. Runtime validation correctly rejects unknown directions and remains unchanged.

## Validation

- Added two regression cases that extract the JSON examples from both READMEs, run direction selection, and verify the selected knowledge files exist. Both failed before the correction and pass afterward.
- Exercised the actual pending-Forge entrypoint with a temporary seed and configuration: the old example raises the reported `ValueError`; the corrected example reaches the Forge call with the intended directions. Model execution was intercepted at that boundary; no paid model request was made.
- The full offline Python suite, Ruff, compilation, model-reference checks, configuration projection, secret scan, release-tree check, and public-knowledge check pass locally.
- README freshness checks and Chinese prose checks pass. Code review found no actionable defects.

## Scope check

- [x] One issue and one independently reviewable change.
- [x] No unrelated source changes, generated data, or credentials.
- [x] Claims verified against executed tests and the runtime entrypoint.
- [x] Checked open PRs before implementation; no overlapping PR was present.

Fixes #1
