### PR TITLE
fix: render an empty dashboard when no projects exist

### DIFF
--- a/src/generate_project_dashboard.py
+++ b/src/generate_project_dashboard.py
@@ -781,7 +781,11 @@ def render_one(slug):
 
 
 def render_all(only=None):
-    slugs = sorted(d.name for d in PROJECTS_DIR.iterdir() if d.is_dir() and (d / "state.md").exists())
+    try:
+        entries = list(PROJECTS_DIR.iterdir())
+    except FileNotFoundError:
+        entries = []
+    slugs = sorted(d.name for d in entries if d.is_dir() and (d / "state.md").exists())
     selected = set(only) if only is not None else None
     unknown = sorted(selected - set(slugs)) if selected is not None else []
     if unknown:

--- a/tests/test_project_dashboard.py
+++ b/tests/test_project_dashboard.py
@@ -308,3 +308,34 @@ def test_declared_project_provenance_cannot_silently_disappear(dashboard) -> Non
 
     with pytest.raises(dashboard.DashboardDataError, match="declares idea_provenance"):
         dashboard.load_project("demo")
+
+
+@pytest.mark.parametrize("missing", [True, False])
+def test_cli_renders_an_empty_project_overview(dashboard, monkeypatch, capsys, missing):
+    if missing:
+        monkeypatch.setattr(dashboard, "PROJECTS_DIR", dashboard.PROJECT_ROOT / "absent" / "projects")
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT), "--all"])
+
+    assert dashboard.main() == 0
+
+    output = capsys.readouterr()
+    assert "(0 projects)" in output.out
+    assert output.err == ""
+    page = (dashboard.PROJECT_ROOT / "dashboard_index.html").read_text(encoding="utf-8")
+    assert "0 projects" in page
+    if missing:
+        assert not dashboard.PROJECTS_DIR.exists()
+
+
+def test_missing_projects_directory_still_rejects_unknown_filter(dashboard, monkeypatch):
+    monkeypatch.setattr(dashboard, "PROJECTS_DIR", dashboard.PROJECT_ROOT / "absent" / "projects")
+    with pytest.raises(SystemExit, match=r"unknown project.*missing.*none"):
+        dashboard.render_all(only={"missing"})
+
+
+def test_projects_path_must_be_a_directory(dashboard, monkeypatch):
+    invalid = dashboard.PROJECT_ROOT / "not-a-directory"
+    invalid.write_text("invalid", encoding="utf-8")
+    monkeypatch.setattr(dashboard, "PROJECTS_DIR", invalid)
+    with pytest.raises(NotADirectoryError):
+        dashboard.render_all()


### PR DESCRIPTION
## What changes

`python src/generate_project_dashboard.py --all` now generates the existing overview with `0 projects` when `data/projects/` does not exist. It does not create an unused projects directory.

## Why

A fresh checkout has no projects directory. Unconditionally iterating over that path raised `FileNotFoundError` before the existing empty-overview renderer could run. The fix handles the missing directory at the enumeration boundary. A non-directory path still raises an error, and `--only` still rejects unknown project names.

## Validation

- Added four regression cases covering missing and empty project directories, an unknown filter with no projects directory, and a projects path that is a regular file. The two missing-directory cases failed before the fix; all four now pass.
- Ran the documented command on a checkout with no projects directory: it exits successfully and reports `0 projects`. Inspected the generated page in a browser and confirmed its empty overview renders correctly.
- The full offline Python suite, Ruff, compilation, model-reference checks, configuration projection, secret scan, release-tree check, and public-knowledge check pass locally.
- Code review found no actionable defects. No model credentials or paid calls were needed.

## Scope check

- [x] One issue and one independently reviewable change.
- [x] Existing populated-project, filtering, and path-boundary tests remain green.
- [x] No unrelated changes, generated pages, or credentials are committed.
- [x] Checked open PRs before implementation; no overlapping PR was present.

Fixes #2
